### PR TITLE
fix(get_at_distance returns the first index): get_at_distance returns the first index no matter the input distance

### DIFF
--- a/py_ballisticcalc/trajectory_data.py
+++ b/py_ballisticcalc/trajectory_data.py
@@ -225,8 +225,7 @@ class HitResult:
         :param d: Distance for which we want Trajectory Data
         :return: First trajectory row with .distance >= d
         """
-        i = self.index_at_distance(d)
-        if i < 0:
+        if (i := self.index_at_distance(d)) < 0:
             raise ArithmeticError(
                 f"Calculated trajectory doesn't reach requested distance {d}"
             )

--- a/py_ballisticcalc/trajectory_data.py
+++ b/py_ballisticcalc/trajectory_data.py
@@ -225,8 +225,8 @@ class HitResult:
         :param d: Distance for which we want Trajectory Data
         :return: First trajectory row with .distance >= d
         """
-
-        if i := self.index_at_distance(d) < 0:
+        i = self.index_at_distance(d)
+        if i < 0:
             raise ArithmeticError(
                 f"Calculated trajectory doesn't reach requested distance {d}"
             )


### PR DESCRIPTION
The way the assignment and comparison are combined leads to an incorrect evaluation.

The line is trying to both assign and compare in a single statement, which results in incorrect logic. The assignment should be done separately from the comparison.