### PR TITLE
Incomplete shot handling

### DIFF
--- a/py_ballisticcalc/trajectory_calc/_trajectory_calc.py
+++ b/py_ballisticcalc/trajectory_calc/_trajectory_calc.py
@@ -221,7 +221,7 @@ class TrajectoryCalc:
         filter_flags = TrajFlag.RANGE
 
         if extra_data:
-            dist_step = Distance.Foot(self._config.chart_resolution)
+            # dist_step = Distance.Foot(self._config.chart_resolution)
             filter_flags = TrajFlag.ALL
 
         self._init_trajectory(shot_info)
@@ -382,6 +382,15 @@ class TrajectoryCalc:
                     or range_vector.y < _cMaximumDrop
                     or self.alt0 + range_vector.y < _cMinimumAltitude
             ):
+
+                # checking that we are not duplicating last point, if it is present
+                if len(ranges)==0 or len(ranges)>0 and ranges[-1].time != time:
+                    # record interruption point
+                    ranges.append(create_trajectory_row(
+                        time, range_vector, velocity_vector,
+                        velocity, mach, self.spin_drift(time), self.look_angle,
+                        density_factor, drag, self.weight, data_filter.current_flag
+                    ))
                 if velocity < _cMinimumVelocity:
                     reason = RangeError.MinimumVelocityReached
                 elif range_vector.y < _cMaximumDrop:

--- a/tests/test_danger_space.py
+++ b/tests/test_danger_space.py
@@ -15,7 +15,7 @@ class TestDangerSpace(unittest.TestCase):
         shot = Shot(weapon=Weapon(), ammo=ammo, winds=current_winds)
         calc = Calculator()
         calc.set_weapon_zero(shot, Distance.Foot(300))
-        self.shot_result = calc.fire(shot, trajectory_range=Distance.Yard(1000), trajectory_step=Distance.Yard(100), extra_data=True)
+        self.shot_result = calc.fire(shot, trajectory_range=Distance.Yard(1000), trajectory_step=Distance.Foot(0.2), extra_data=True)
 
     def test_danger_space(self):
         danger_space = self.shot_result.danger_space(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -137,7 +137,7 @@ def test_find_index_for_distance(one_degree_shot):
     )
     # for reproducibility
     random.seed(42)
-    random_indices = random.sample(range(len(shot.trajectory)), 100)
+    random_indices = random.sample(range(len(shot.trajectory)), min(100, len(shot.trajectory)))
     start_time = time.time()
 
     for i in random_indices:

--- a/tests/test_incomplete_shots.py
+++ b/tests/test_incomplete_shots.py
@@ -1,0 +1,115 @@
+import pytest
+from py_ballisticcalc import (
+    DragModel,
+    TableG1,
+    Weight,
+    Distance,
+    Ammo,
+    Velocity,
+    Weapon,
+    InterfaceConfigDict,
+    Calculator,
+    Shot,
+    Angular,
+    RangeError,
+    HitResult,
+)
+
+def print_out_trajectory_compact(hit_result:HitResult, distance_unit: Distance=Distance.Meter):
+    for i, p in enumerate(hit_result.trajectory):
+        print(f'{i+1}. ({p.distance>>distance_unit}, {p.height>>distance_unit})')
+
+def test_shot_incomplete():
+    drag_model = DragModel(
+        bc=0.759,
+        drag_table=TableG1,
+        weight=Weight.Gram(108),
+        diameter=Distance.Millimeter(23),
+        length=Distance.Millimeter(108.2),
+    )
+    ammo = Ammo(drag_model, Velocity.MPS(930))
+
+    gun = Weapon()
+    config = InterfaceConfigDict(
+        cMinimumVelocity=0,
+        cMinimumAltitude=Distance.Meter(0),
+        cMaximumDrop=Distance.Meter(0),
+    )
+    angle_in_degrees = 5.219710693607955
+    distance = 6937.3716148080375
+    shot = Shot(
+        weapon=gun,
+        ammo=ammo,
+        relative_angle=Angular.Degree(angle_in_degrees),
+    )
+
+    range = Distance.Meter(distance)
+
+    calc = Calculator(_config=config)
+    try:
+        extra_data = False
+        hit_result=calc.fire(shot, range, extra_data=extra_data)
+    except RangeError as e:
+        print(f'{e.reason} {len(e.incomplete_trajectory)=}')
+        if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
+            hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
+    print(f'{len(hit_result.trajectory)=}')
+    print_out_trajectory_compact(hit_result)
+#    print(f'{hit_result.trajectory=}')
+
+    last_point_distance = hit_result[-1].distance >> Distance.Meter
+    last_point_height = hit_result[-1].height >> Distance.Meter
+    print(f"{ last_point_distance=} { last_point_height=}")
+    assert last_point_distance == pytest.approx(3525.0, abs=0.2)
+    assert last_point_height == pytest.approx(0.0, abs=0.1)
+
+    try:
+        extra_data = False
+        hit_result=calc.fire(shot, range, extra_data=extra_data, trajectory_step=range)
+    except RangeError as e:
+        print(f'{e.reason} {len(e.incomplete_trajectory)=}')
+        if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
+            hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
+    print(f'{len(hit_result.trajectory)=}')
+    print_out_trajectory_compact(hit_result)
+
+    last_point_distance = hit_result[-1].distance >> Distance.Meter
+    last_point_height = hit_result[-1].height >> Distance.Meter
+    print(f"{ last_point_distance=} { last_point_height=}")
+    assert last_point_distance == pytest.approx(3525.0, abs=0.2)
+    assert last_point_height == pytest.approx(0.0, abs=0.1)
+
+
+    calc = Calculator(_config=config)
+    try:
+        extra_data = True
+        hit_result=calc.fire(shot, range, extra_data=extra_data)
+    except RangeError as e:
+        print(f'{e.reason} {len(e.incomplete_trajectory)=}')
+        if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
+            hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
+    print(f'{len(hit_result.trajectory)=}')
+    print_out_trajectory_compact(hit_result)
+
+    last_point_distance = hit_result[-1].distance >> Distance.Meter
+    last_point_height = hit_result[-1].height >> Distance.Meter
+    print(f"{ last_point_distance=} { last_point_height=}")
+    assert last_point_distance == pytest.approx(3525.0, abs=0.2)
+    assert last_point_height == pytest.approx(0.0, abs=0.1)
+
+    calc = Calculator(_config=config)
+    try:
+        extra_data = True
+        hit_result=calc.fire(shot, range, extra_data=extra_data, trajectory_step=range)
+    except RangeError as e:
+        print(f'{e.reason} {len(e.incomplete_trajectory)=}')
+        if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
+            hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
+    print(f'{len(hit_result.trajectory)=}')
+    print_out_trajectory_compact(hit_result)
+
+    last_point_distance = hit_result[-1].distance >> Distance.Meter
+    last_point_height = hit_result[-1].height >> Distance.Meter
+    print(f"{ last_point_distance=} { last_point_height=}")
+    assert last_point_distance == pytest.approx(3525.0, abs=0.2)
+    assert last_point_height == pytest.approx(0.0, abs=0.1)

--- a/tests/test_incomplete_shots.py
+++ b/tests/test_incomplete_shots.py
@@ -16,10 +16,21 @@ from py_ballisticcalc import (
 )
 
 def print_out_trajectory_compact(hit_result:HitResult, distance_unit: Distance=Distance.Meter):
+    print(f'Length of trajectory: {len(hit_result.trajectory)=}')
     for i, p in enumerate(hit_result.trajectory):
         print(f'{i+1}. ({p.distance>>distance_unit}, {p.height>>distance_unit})')
 
-def test_shot_incomplete():
+@pytest.fixture()
+def zero_height_calc():
+    config = InterfaceConfigDict(
+        cMinimumVelocity=0,
+        cMinimumAltitude=Distance.Meter(0),
+        cMaximumDrop=Distance.Meter(0),
+    )
+    calc = Calculator(_config=config)
+    return calc
+
+def shot_with_relative_angle_in_degrees(angle_in_degrees: float):
     drag_model = DragModel(
         bc=0.759,
         drag_table=TableG1,
@@ -28,34 +39,31 @@ def test_shot_incomplete():
         length=Distance.Millimeter(108.2),
     )
     ammo = Ammo(drag_model, Velocity.MPS(930))
-
     gun = Weapon()
-    config = InterfaceConfigDict(
-        cMinimumVelocity=0,
-        cMinimumAltitude=Distance.Meter(0),
-        cMaximumDrop=Distance.Meter(0),
-    )
-    angle_in_degrees = 5.219710693607955
-    distance = 6937.3716148080375
     shot = Shot(
         weapon=gun,
         ammo=ammo,
         relative_angle=Angular.Degree(angle_in_degrees),
     )
+    return shot
 
+
+def test_shot_incomplete(zero_height_calc):
+
+    angle_in_degrees = 5.219710693607955
+    distance = 6937.3716148080375
+
+    shot = shot_with_relative_angle_in_degrees(angle_in_degrees)
     range = Distance.Meter(distance)
 
-    calc = Calculator(_config=config)
     try:
         extra_data = False
-        hit_result=calc.fire(shot, range, extra_data=extra_data)
+        hit_result= zero_height_calc.fire(shot, range, extra_data=extra_data)
     except RangeError as e:
         print(f'{e.reason} {len(e.incomplete_trajectory)=}')
         if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
             hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
-    print(f'{len(hit_result.trajectory)=}')
     print_out_trajectory_compact(hit_result)
-#    print(f'{hit_result.trajectory=}')
 
     last_point_distance = hit_result[-1].distance >> Distance.Meter
     last_point_height = hit_result[-1].height >> Distance.Meter
@@ -65,51 +73,67 @@ def test_shot_incomplete():
 
     try:
         extra_data = False
-        hit_result=calc.fire(shot, range, extra_data=extra_data, trajectory_step=range)
+        hit_result= zero_height_calc.fire(shot, range, extra_data=extra_data, trajectory_step=range)
     except RangeError as e:
         print(f'{e.reason} {len(e.incomplete_trajectory)=}')
         if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
             hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
-    print(f'{len(hit_result.trajectory)=}')
     print_out_trajectory_compact(hit_result)
 
     last_point_distance = hit_result[-1].distance >> Distance.Meter
     last_point_height = hit_result[-1].height >> Distance.Meter
-    print(f"{ last_point_distance=} { last_point_height=}")
     assert last_point_distance == pytest.approx(3525.0, abs=0.2)
     assert last_point_height == pytest.approx(0.0, abs=0.1)
 
-
-    calc = Calculator(_config=config)
     try:
         extra_data = True
-        hit_result=calc.fire(shot, range, extra_data=extra_data)
+        hit_result= zero_height_calc.fire(shot, range, extra_data=extra_data)
     except RangeError as e:
         print(f'{e.reason} {len(e.incomplete_trajectory)=}')
         if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
             hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
-    print(f'{len(hit_result.trajectory)=}')
     print_out_trajectory_compact(hit_result)
 
     last_point_distance = hit_result[-1].distance >> Distance.Meter
     last_point_height = hit_result[-1].height >> Distance.Meter
-    print(f"{ last_point_distance=} { last_point_height=}")
     assert last_point_distance == pytest.approx(3525.0, abs=0.2)
     assert last_point_height == pytest.approx(0.0, abs=0.1)
 
-    calc = Calculator(_config=config)
     try:
         extra_data = True
-        hit_result=calc.fire(shot, range, extra_data=extra_data, trajectory_step=range)
+        hit_result= zero_height_calc.fire(shot, range, extra_data=extra_data, trajectory_step=range)
     except RangeError as e:
         print(f'{e.reason} {len(e.incomplete_trajectory)=}')
         if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
             hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
-    print(f'{len(hit_result.trajectory)=}')
     print_out_trajectory_compact(hit_result)
 
     last_point_distance = hit_result[-1].distance >> Distance.Meter
     last_point_height = hit_result[-1].height >> Distance.Meter
-    print(f"{ last_point_distance=} { last_point_height=}")
     assert last_point_distance == pytest.approx(3525.0, abs=0.2)
     assert last_point_height == pytest.approx(0.0, abs=0.1)
+
+def test_vertical_shot(zero_height_calc):
+    shot = shot_with_relative_angle_in_degrees(90)
+    range=Distance.Meter(10)
+    try:
+        extra_data=False
+        hit_result = zero_height_calc.fire(shot, range, extra_data=extra_data)
+    except RangeError as e:
+        print(f'{e.reason} {len(e.incomplete_trajectory)=}')
+        if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
+            hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
+    print_out_trajectory_compact(hit_result)
+    assert hit_result[-1].distance>>Distance.Meter == pytest.approx(0, abs=1e-10)
+    assert hit_result[-1].height>>Distance.Meter == pytest.approx(0, abs=0.1)
+
+    try:
+        extra_data=True
+        hit_result = zero_height_calc.fire(shot, range, extra_data=extra_data)
+    except RangeError as e:
+        print(f'{e.reason} {len(e.incomplete_trajectory)=}')
+        if e.reason in[ RangeError.MaximumDropReached, RangeError.MinimumAltitudeReached]:
+            hit_result = HitResult(shot, e.incomplete_trajectory, extra=extra_data)
+    print_out_trajectory_compact(hit_result)
+    assert hit_result[-1].distance>>Distance.Meter == pytest.approx(0, abs=1e-10)
+    assert hit_result[-1].height>>Distance.Meter == pytest.approx(0, abs=0.1)


### PR DESCRIPTION
Removal of usage of chart_resolution for extra_data=True

Changes that ensure that point, at which trajectory was interrupted are getting added to the incomplete_trajectory in case of RangeError.

Change of TestDangerSpace test to use trajectory_step=Distance.Foot(0.2) in order to run again after removal of usage of chart_resolution.

@o-murphy  - Feel free to improve things, which you consider should be done differently (for example, passing to DangerSpaceTest chart_resolution_step, or anything else)