### PR TITLE
fix[doc]: docstring for usage of ShotProps.spin_drift

### DIFF
--- a/py_ballisticcalc/shot.py
+++ b/py_ballisticcalc/shot.py
@@ -423,4 +423,3 @@ class ShotProps:
         xs = [dp.Mach for dp in data_points]
         ys = [dp.CD for dp in data_points]
         return pchip_prepare(xs, ys)
-


### PR DESCRIPTION
The docstring on `ShotProps.spin_drift` in `shot.py` says it returns the spin drift in inches, but that's not correct. Internally, it divides by 12 to get feet, because that's the units used by the `adjusted_range: Vector`.

I had reached into the `spin_drift` method to help me decide if the difference in spin drift between different types of ammunition was significant enough to worry about, but then found the results were erroneously small. In the end, the spin drift math is all correctly handled in the final tables (I've checked), but I spent a fair amount of time trying to sort out where the trouble was.

I'll note that the documentation for `BCLIBC_ShotProps::spin_drift` in `base_types.cpp` correctly notes the return type being in feet, so no changes were needed there.
